### PR TITLE
feat: rename Custom Type-related methods to include "CustomType"

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -130,6 +130,12 @@ export class CustomTypesClient {
 	}
 
 	/**
+	 * @deprecated Renamed to `getAllCustomTypes`.
+	 */
+	// TODO: Remove in v1.
+	getAll = this.getAllCustomTypes.bind(this);
+
+	/**
 	 * Returns all Custom Types models from the Prismic repository.
 	 *
 	 * @typeParam TCustomType - The Custom Type returned from the API.
@@ -138,11 +144,17 @@ export class CustomTypesClient {
 	 * @returns All Custom Type models from the Prismic repository.
 	 * @throws {@link ForbiddenError} Thrown if the client is unauthorized to make requests.
 	 */
-	async getAll<TCustomType extends prismicT.CustomTypeModel>(
+	async getAllCustomTypes<TCustomType extends prismicT.CustomTypeModel>(
 		params?: CustomTypesClientMethodParams,
 	): Promise<TCustomType[]> {
 		return await this.fetch<TCustomType[]>("", params);
 	}
+
+	/**
+	 * @deprecated Renamed to `getCustomTypeByID`.
+	 */
+	// TODO: Remove in v1.
+	getByID = this.getCustomTypeByID.bind(this);
 
 	/**
 	 * Returns a Custom Type model with a given ID from the Prismic repository.
@@ -156,12 +168,18 @@ export class CustomTypesClient {
 	 * @throws {@link NotFoundError} Thrown if a Custom Type with the given ID
 	 *   cannot be found.
 	 */
-	async getByID<TCustomType extends prismicT.CustomTypeModel>(
+	async getCustomTypeByID<TCustomType extends prismicT.CustomTypeModel>(
 		id: string,
 		params?: CustomTypesClientMethodParams,
 	): Promise<TCustomType> {
 		return await this.fetch<TCustomType>(id, params);
 	}
+
+	/**
+	 * @deprecated Renamed to `insertCustomType`.
+	 */
+	// TODO: Remove in v1.
+	insert = this.insertCustomType.bind(this);
 
 	/**
 	 * Inserts a Custom Type model to the Prismic repository.
@@ -176,7 +194,7 @@ export class CustomTypesClient {
 	 * @throws {@link ConflictError} Thrown if a Custom Type with the given ID
 	 *   already exists.
 	 */
-	async insert<TCustomType extends prismicT.CustomTypeModel>(
+	async insertCustomType<TCustomType extends prismicT.CustomTypeModel>(
 		customType: TCustomType,
 		params?: CustomTypesClientMethodParams,
 	): Promise<TCustomType> {
@@ -188,6 +206,12 @@ export class CustomTypesClient {
 
 		return customType;
 	}
+
+	/**
+	 * @deprecated Renamed to `updateCustomType`.
+	 */
+	// TODO: Remove in v1.
+	update = this.updateCustomType.bind(this);
 
 	/**
 	 * Updates a Custom Type model from the Prismic repository.
@@ -202,7 +226,7 @@ export class CustomTypesClient {
 	 * @throws {@link NotFoundError} Thrown if a Custom Type with the given ID
 	 *   cannot be found.
 	 */
-	async update<TCustomType extends prismicT.CustomTypeModel>(
+	async updateCustomType<TCustomType extends prismicT.CustomTypeModel>(
 		customType: TCustomType,
 		params?: CustomTypesClientMethodParams,
 	): Promise<TCustomType> {
@@ -216,6 +240,12 @@ export class CustomTypesClient {
 	}
 
 	/**
+	 * @deprecated Renamed to `removeCustomType`.
+	 */
+	// TODO: Remove in v1.
+	remove = this.removeCustomType.bind(this);
+
+	/**
 	 * Removes a Custom Type model from the Prismic repository.
 	 *
 	 * @typeParam TCustomTypeID - The ID of the Custom Type.
@@ -225,7 +255,7 @@ export class CustomTypesClient {
 	 * @returns The ID of the removed Custom Type.
 	 * @throws {@link ForbiddenError} Thrown if the client is unauthorized to make requests.
 	 */
-	async remove<TCustomTypeID extends string>(
+	async removeCustomType<TCustomTypeID extends string>(
 		id: TCustomTypeID,
 		params?: CustomTypesClientMethodParams,
 	): Promise<TCustomTypeID> {

--- a/test/client-getAllCustomTypes.test.ts
+++ b/test/client-getAllCustomTypes.test.ts
@@ -29,7 +29,7 @@ test("returns all Custom Types", async (t) => {
 		}),
 	);
 
-	const res = await client.getAll();
+	const res = await client.getAllCustomTypes();
 
 	t.deepEqual(res, queryResponse);
 });
@@ -56,7 +56,7 @@ test("uses params if provided", async (t) => {
 		}),
 	);
 
-	const res = await client.getAll(params);
+	const res = await client.getAllCustomTypes(params);
 
 	t.deepEqual(res, queryResponse);
 });

--- a/test/client-getCustomTypeByID.test.ts
+++ b/test/client-getCustomTypeByID.test.ts
@@ -33,7 +33,7 @@ test("returns a Custom Type by ID", async (t) => {
 		),
 	);
 
-	const res = await client.getByID(customType.id);
+	const res = await client.getCustomTypeByID(customType.id);
 
 	t.deepEqual(res, customType);
 });
@@ -63,7 +63,7 @@ test("uses params if provided", async (t) => {
 		),
 	);
 
-	const res = await client.getByID(customType.id, params);
+	const res = await client.getCustomTypeByID(customType.id, params);
 
 	t.deepEqual(res, customType);
 });
@@ -88,7 +88,10 @@ test("throws NotFoundError if a matching Custom Type was not found", async (t) =
 		),
 	);
 
-	await t.throwsAsync(async () => await client.getByID(customType.id), {
-		instanceOf: prismicCustomTypes.NotFoundError,
-	});
+	await t.throwsAsync(
+		async () => await client.getCustomTypeByID(customType.id),
+		{
+			instanceOf: prismicCustomTypes.NotFoundError,
+		},
+	);
 });

--- a/test/client-insertCustomType.test.ts
+++ b/test/client-insertCustomType.test.ts
@@ -33,7 +33,7 @@ test("inserts a Custom Type", async (t) => {
 		}),
 	);
 
-	const res = await client.insert(customType);
+	const res = await client.insertCustomType(customType);
 
 	t.deepEqual(res, customType);
 });
@@ -62,7 +62,7 @@ test("uses params if provided", async (t) => {
 		}),
 	);
 
-	const res = await client.insert(customType, params);
+	const res = await client.insertCustomType(customType, params);
 
 	t.deepEqual(res, customType);
 });
@@ -86,7 +86,7 @@ test("throws ConflictError if a Custom Type with the same ID already exists", as
 		}),
 	);
 
-	await t.throwsAsync(async () => await client.insert(customType), {
+	await t.throwsAsync(async () => await client.insertCustomType(customType), {
 		instanceOf: prismicCustomTypes.ConflictError,
 	});
 });
@@ -111,7 +111,7 @@ test("throws InvalidPayloadError if an invalid Custom Type is sent", async (t) =
 		}),
 	);
 
-	await t.throwsAsync(async () => await client.insert(customType), {
+	await t.throwsAsync(async () => await client.insertCustomType(customType), {
 		instanceOf: prismicCustomTypes.InvalidPayloadError,
 		message,
 	});

--- a/test/client-removeCustomType.test.ts
+++ b/test/client-removeCustomType.test.ts
@@ -33,7 +33,7 @@ test("removes a Custom Type", async (t) => {
 		),
 	);
 
-	const res = await client.remove(customType.id);
+	const res = await client.removeCustomType(customType.id);
 
 	t.deepEqual(res, customType.id);
 });
@@ -63,7 +63,7 @@ test("uses params if provided", async (t) => {
 		),
 	);
 
-	const res = await client.remove(customType.id, params);
+	const res = await client.removeCustomType(customType.id, params);
 
 	t.deepEqual(res, customType.id);
 });

--- a/test/client-updateCustomType.test.ts
+++ b/test/client-updateCustomType.test.ts
@@ -33,7 +33,7 @@ test("updates a Custom Type", async (t) => {
 		}),
 	);
 
-	const res = await client.update(customType);
+	const res = await client.updateCustomType(customType);
 
 	t.deepEqual(res, customType);
 });
@@ -62,7 +62,7 @@ test("uses params if provided", async (t) => {
 		}),
 	);
 
-	const res = await client.update(customType, params);
+	const res = await client.updateCustomType(customType, params);
 
 	t.deepEqual(res, customType);
 });
@@ -86,7 +86,7 @@ test("throws NotFoundError if a matching Custom Type was not found", async (t) =
 		}),
 	);
 
-	await t.throwsAsync(async () => await client.update(customType), {
+	await t.throwsAsync(async () => await client.updateCustomType(customType), {
 		instanceOf: prismicCustomTypes.NotFoundError,
 	});
 });
@@ -111,7 +111,7 @@ test("throws InvalidPayloadError if an invalid Custom Type is sent", async (t) =
 		}),
 	);
 
-	await t.throwsAsync(async () => await client.update(customType), {
+	await t.throwsAsync(async () => await client.updateCustomType(customType), {
 		instanceOf: prismicCustomTypes.InvalidPayloadError,
 		message,
 	});

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -92,7 +92,7 @@ test("throws ForbiddenError if unauthorized", async (t) => {
 		}),
 	);
 
-	await t.throwsAsync(async () => await client.getAll(), {
+	await t.throwsAsync(async () => await client.getAllCustomTypes(), {
 		instanceOf: prismicCustomTypes.ForbiddenError,
 	});
 });
@@ -108,7 +108,7 @@ test("throws PrismicError if an unsupported response is returned", async (t) => 
 		}),
 	);
 
-	await t.throwsAsync(async () => await client.getAll(), {
+	await t.throwsAsync(async () => await client.getAllCustomTypes(), {
 		instanceOf: prismicCustomTypes.PrismicError,
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR renames all Custom Type-related methods could include a "CustomType" identifier, just like the Shared Slice-related methods.

The existing methods are still included in the client as aliases, but are deprecated. Please upgrade to the renamed methods.

Old:

```typescript
const customTypeModels = await client.getAll();
const sharedSliceModels = await client.getAllSharedSlices();
```

New:

```typescript
const customTypeModels = await client.getAllCustomTypes();
const sharedSliceModels = await client.getAllSharedSlices();
```

Closes #1

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐭
