### PR TITLE
feat: Add the possibility to set a User-Agent header

### DIFF
--- a/examples/custom-types/index.ts
+++ b/examples/custom-types/index.ts
@@ -11,10 +11,16 @@ const PRISMIC_REPOSITORY_NAME = "qwerty";
  */
 const PRISMIC_CUSTOM_TYPES_API_TOKEN = "secret-token";
 
+/**
+ * The "User-Agent" header to use.
+ */
+const userAgent = "custom-user-agent";
+
 const main = async () => {
 	const customTypesClient = prismicCustomTypes.createClient({
 		repositoryName: PRISMIC_REPOSITORY_NAME,
 		token: PRISMIC_CUSTOM_TYPES_API_TOKEN,
+		userAgent,
 		fetch,
 	});
 

--- a/examples/shared-slices/index.ts
+++ b/examples/shared-slices/index.ts
@@ -11,10 +11,16 @@ const PRISMIC_REPOSITORY_NAME = "qwerty";
  */
 const PRISMIC_CUSTOM_TYPES_API_TOKEN = "secret-token";
 
+/**
+ * The "User-Agent" header to use.
+ */
+const userAgent = "custom-user-agent";
+
 const main = async () => {
 	const customTypesClient = prismicCustomTypes.createClient({
 		repositoryName: PRISMIC_REPOSITORY_NAME,
 		token: PRISMIC_CUSTOM_TYPES_API_TOKEN,
+		userAgent,
 		fetch,
 	});
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,7 +33,7 @@ export type CustomTypesClientConfig = {
 
 	/**
 	 * The secure token for accessing the Prismic Custom Types API. This is
-	 * required to call any Custom Type API methods.
+	 * required to call any Custom Types API methods.
 	 */
 	token: string;
 
@@ -43,6 +43,12 @@ export type CustomTypesClientConfig = {
 	 * Node.js, this function must be provided.
 	 */
 	fetch?: FetchLike;
+
+	/**
+	 * The "User-Agent" header used in all outgoing requests to the Custom Types
+	 * API. It's used by the Custom Types API for tracking purposes.
+	 */
+	userAgent?: string;
 };
 
 /**
@@ -50,7 +56,10 @@ export type CustomTypesClientConfig = {
  * override the client's default values, if present.
  */
 export type CustomTypesClientMethodParams = Partial<
-	Pick<CustomTypesClientConfig, "repositoryName" | "endpoint" | "token">
+	Pick<
+		CustomTypesClientConfig,
+		"repositoryName" | "endpoint" | "token" | "userAgent"
+	>
 >;
 
 /**
@@ -110,7 +119,7 @@ export class CustomTypesClient {
 
 	/**
 	 * The secure token for accessing the Prismic Custom Types API. This is
-	 * required to call any Custom Type API methods.
+	 * required to call any Custom Types API methods.
 	 */
 	token: string;
 
@@ -122,12 +131,19 @@ export class CustomTypesClient {
 	fetchFn: FetchLike;
 
 	/**
+	 * The "User-Agent" header used in all outgoing requests to the Custom Type
+	 * API. It's used by the Custom Types API for tracking purposes.
+	 */
+	userAgent?: string;
+
+	/**
 	 * Create a client for the Prismic Custom Types API.
 	 */
 	constructor(config: CustomTypesClientConfig) {
 		this.repositoryName = config.repositoryName;
 		this.endpoint = config.endpoint || DEFAULT_CUSTOM_TYPES_API_ENDPOINT;
 		this.token = config.token;
+		this.userAgent = config.userAgent;
 
 		// TODO: Remove the following `if` statement in v2.
 		//
@@ -417,12 +433,14 @@ export class CustomTypesClient {
 			path,
 			endpoint.endsWith("/") ? endpoint : `${endpoint}/`,
 		).toString();
+		const userAgent = params.userAgent || this.userAgent;
 
 		const res = await this.fetchFn(url, {
 			headers: {
 				"Content-Type": "application/json",
 				repository: params.repositoryName || this.repositoryName,
 				Authorization: `Bearer ${params.token || this.token}`,
+				...(userAgent && { "User-Agent": userAgent }),
 			},
 			signal: params.signal,
 			...requestInit,

--- a/test/client-getAllCustomTypes.test.ts
+++ b/test/client-getAllCustomTypes.test.ts
@@ -38,6 +38,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-getAllSharedSlices.test.ts
+++ b/test/client-getAllSharedSlices.test.ts
@@ -38,6 +38,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-getCustomTypeByID.test.ts
+++ b/test/client-getCustomTypeByID.test.ts
@@ -38,6 +38,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-getSharedSliceByID.test.ts
+++ b/test/client-getSharedSliceByID.test.ts
@@ -38,6 +38,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-insertCustomType.test.ts
+++ b/test/client-insertCustomType.test.ts
@@ -41,6 +41,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-insertSharedSlice.test.ts
+++ b/test/client-insertSharedSlice.test.ts
@@ -41,6 +41,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-removeCustomType.test.ts
+++ b/test/client-removeCustomType.test.ts
@@ -38,6 +38,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-removeSharedSlice.test.ts
+++ b/test/client-removeSharedSlice.test.ts
@@ -38,6 +38,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-updateCustomType.test.ts
+++ b/test/client-updateCustomType.test.ts
@@ -41,6 +41,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(

--- a/test/client-updateSharedSlice.test.ts
+++ b/test/client-updateSharedSlice.test.ts
@@ -41,6 +41,7 @@ test("uses params if provided", async (ctx) => {
 		repositoryName: "custom-repositoryName",
 		token: "custom-token",
 		endpoint: "https://custom-endpoint.example.com",
+		userAgent: "custom-user-agent",
 	};
 
 	ctx.server.use(


### PR DESCRIPTION
## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- The Custom Types API have a tracking mechanism that require to add a user agent in the header of the requests. It's not possible in the current version of the client. This PR add a new configuration property to do this 
- Relative to [DT-1294 - (Regression) Tracking - AAPM I should see events of Custom Type Created and Shared Slice Created after the /init command automatically pushes models when ran with a starter](https://linear.app/prismic/issue/DT-1294/regression-tracking-aapm-i-should-see-events-of-custom-type-created) 

## Checklist:

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.
