### PR TITLE
feat: pass arbitrary options to `fetch()` with the `fetchOptions` parameter

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,15 +22,35 @@ export type FetchLike = (
 export type AbortSignalLike = any;
 
 /**
- * The minimum required properties from RequestInit.
+ * A subset of RequestInit properties to configure a `fetch()` request.
  */
-export interface RequestInitLike {
+// Only options relevant to the client are included. Extending from the full
+// RequestInit would cause issues, such as accepting Header objects.
+//
+// An interface is used to allow other libraries to augment the type with
+// environment-specific types.
+export interface RequestInitLike extends Pick<RequestInit, "cache"> {
 	// Explicit method names are given for compatibility with `fetch-h2`.
 	// Most fetch implementation use `method?: string`, which is compatible
 	// with the version defiend here.
 	method?: "GET" | "POST" | "DELETE";
+
 	body?: string;
+
+	/**
+	 * An object literal to set the `fetch()` request's headers.
+	 */
 	headers?: Record<string, string>;
+
+	/**
+	 * An AbortSignal to set the `fetch()` request's signal.
+	 *
+	 * See:
+	 * [https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+	 */
+	// NOTE: `AbortSignalLike` is `any`! It is left as `AbortSignalLike`
+	// for backwards compatibility (the type is exported) and to signal to
+	// other readers that this should be an AbortSignal-like object.
 	signal?: AbortSignalLike;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type AbortSignalLike = any;
 //
 // An interface is used to allow other libraries to augment the type with
 // environment-specific types.
-export interface RequestInitLike extends Pick<RequestInit, "cache"> {
+export interface RequestInitLike extends Partial<Pick<RequestInit, "cache">> {
 	// Explicit method names are given for compatibility with `fetch-h2`.
 	// Most fetch implementation use `method?: string`, which is compatible
 	// with the version defiend here.

--- a/test/__testutils__/testFetchOptions.ts
+++ b/test/__testutils__/testFetchOptions.ts
@@ -1,0 +1,113 @@
+import { expect, it, vi } from "vitest";
+import * as msw from "msw";
+
+import fetch from "node-fetch";
+
+import { createClient } from "./createClient";
+import { isAuthorizedRequest } from "./isAuthorizedRequest";
+
+import * as lib from "../../src";
+
+type TestFetchOptionsArgs = {
+	mockURL: (client: lib.CustomTypesClient) => URL;
+	mockURLMethod?: keyof typeof msw.rest;
+	run: (
+		client: lib.CustomTypesClient,
+		params?: Parameters<lib.CustomTypesClient["getAllCustomTypes"]>[0],
+	) => Promise<unknown>;
+};
+
+export const testFetchOptions = (
+	description: string,
+	args: TestFetchOptionsArgs,
+): void => {
+	it.concurrent(`${description} (on client)`, async (ctx) => {
+		const abortController = new AbortController();
+
+		const fetchSpy = vi.fn(fetch);
+		const fetchOptions: lib.RequestInitLike = {
+			cache: "no-store",
+			headers: {
+				foo: "bar",
+			},
+			signal: abortController.signal,
+		};
+
+		const client = createClient(ctx, {
+			fetch: fetchSpy,
+			fetchOptions,
+		});
+
+		ctx.server.use(
+			msw.rest[args.mockURLMethod || "get"](
+				args.mockURL(client).toString(),
+				(req, res, ctx) => {
+					if (!isAuthorizedRequest(client, req)) {
+						return res(
+							ctx.status(403),
+							ctx.json({ message: "[MOCK FORBIDDEN ERROR]" }),
+						);
+					}
+
+					return res(ctx.json({}));
+				},
+			),
+		);
+
+		await args.run(client);
+
+		for (const [input, init] of fetchSpy.mock.calls) {
+			expect(init, input.toString()).toStrictEqual(
+				expect.objectContaining({
+					...fetchOptions,
+					headers: expect.objectContaining(fetchOptions.headers),
+				}),
+			);
+		}
+	});
+
+	it.concurrent(`${description} (on method)`, async (ctx) => {
+		const abortController = new AbortController();
+
+		const fetchSpy = vi.fn(fetch);
+		const fetchOptions: lib.RequestInitLike = {
+			cache: "no-store",
+			headers: {
+				foo: "bar",
+			},
+			signal: abortController.signal,
+		};
+
+		const client = createClient(ctx, {
+			fetch: fetchSpy,
+		});
+
+		const queryResponse = [ctx.mock.model.customType()];
+		ctx.server.use(
+			msw.rest[args.mockURLMethod || "get"](
+				args.mockURL(client).toString(),
+				(req, res, ctx) => {
+					if (!isAuthorizedRequest(client, req)) {
+						return res(
+							ctx.status(403),
+							ctx.json({ message: "[MOCK FORBIDDEN ERROR]" }),
+						);
+					}
+
+					return res(ctx.json(queryResponse));
+				},
+			),
+		);
+
+		await args.run(client, { fetchOptions });
+
+		for (const [input, init] of fetchSpy.mock.calls) {
+			expect(init, input.toString()).toStrictEqual(
+				expect.objectContaining({
+					...fetchOptions,
+					headers: expect.objectContaining(fetchOptions.headers),
+				}),
+			);
+		}
+	});
+};

--- a/test/client-getAllCustomTypes.test.ts
+++ b/test/client-getAllCustomTypes.test.ts
@@ -3,6 +3,7 @@ import * as msw from "msw";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -70,4 +71,9 @@ test("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.getAllCustomTypes({ signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./customtypes", client.endpoint),
+	run: (client, params) => client.getAllCustomTypes(params),
 });

--- a/test/client-getAllSharedSlices.test.ts
+++ b/test/client-getAllSharedSlices.test.ts
@@ -3,6 +3,7 @@ import * as msw from "msw";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -70,4 +71,9 @@ test("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.getAllSharedSlices({ signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./slices", client.endpoint),
+	run: (client, params) => client.getAllSharedSlices(params),
 });

--- a/test/client-getCustomTypeByID.test.ts
+++ b/test/client-getCustomTypeByID.test.ts
@@ -3,6 +3,7 @@ import * as msw from "msw";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -95,4 +96,9 @@ test("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.getCustomTypeByID("id", { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./customtypes/id", client.endpoint),
+	run: (client, params) => client.getCustomTypeByID("id", params),
 });

--- a/test/client-getSharedSliceByID.test.ts
+++ b/test/client-getSharedSliceByID.test.ts
@@ -3,6 +3,7 @@ import * as msw from "msw";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -95,4 +96,9 @@ test("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.getSharedSliceByID("id", { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./slices/id", client.endpoint),
+	run: (client, params) => client.getSharedSliceByID("id", params),
 });

--- a/test/client-insertCustomType.test.ts
+++ b/test/client-insertCustomType.test.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
+import * as prismicT from "@prismicio/types";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -133,4 +135,11 @@ test.skip("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.insertCustomType(customType, { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./customtypes/insert", client.endpoint),
+	mockURLMethod: "post",
+	run: (client, params) =>
+		client.insertCustomType({} as prismicT.CustomTypeModel, params),
 });

--- a/test/client-insertSharedSlice.test.ts
+++ b/test/client-insertSharedSlice.test.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
+import * as prismicT from "@prismicio/types";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -135,4 +137,11 @@ test.skip("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.insertSharedSlice(sharedSlice, { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./slices/insert", client.endpoint),
+	mockURLMethod: "post",
+	run: (client, params) =>
+		client.insertSharedSlice({} as prismicT.SharedSliceModel, params),
 });

--- a/test/client-removeCustomType.test.ts
+++ b/test/client-removeCustomType.test.ts
@@ -3,6 +3,7 @@ import * as msw from "msw";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -70,6 +71,12 @@ test("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.removeCustomType("id", { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./customtypes/id", client.endpoint),
+	mockURLMethod: "delete",
+	run: (client, params) => client.removeCustomType("id", params),
 });
 
 // NOTE: The API does not return a 4xx status code if a non-existing Custom Type

--- a/test/client-removeSharedSlice.test.ts
+++ b/test/client-removeSharedSlice.test.ts
@@ -3,6 +3,7 @@ import * as msw from "msw";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -70,6 +71,12 @@ test("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.removeSharedSlice("id", { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./slices/id", client.endpoint),
+	mockURLMethod: "delete",
+	run: (client, params) => client.removeSharedSlice("id", params),
 });
 
 // NOTE: The API does not return a 4xx status code if a non-existing Shared

--- a/test/client-updateCustomType.test.ts
+++ b/test/client-updateCustomType.test.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
+import * as prismicT from "@prismicio/types";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -133,4 +135,11 @@ test.skip("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.updateCustomType(customType, { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./customtypes/update", client.endpoint),
+	mockURLMethod: "post",
+	run: (client, params) =>
+		client.updateCustomType({} as prismicT.CustomTypeModel, params),
 });

--- a/test/client-updateSharedSlice.test.ts
+++ b/test/client-updateSharedSlice.test.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
+import * as prismicT from "@prismicio/types";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismicCustomTypes from "../src";
 
@@ -135,4 +137,11 @@ test.skip("is abortable", async (ctx) => {
 	await expect(async () => {
 		await client.updateSharedSlice(sharedSlice, { signal: controller.signal });
 	}).rejects.toThrow(/aborted/i);
+});
+
+testFetchOptions("supports fetch options", {
+	mockURL: (client) => new URL("./slices/update", client.endpoint),
+	mockURLMethod: "post",
+	run: (client, params) =>
+		client.updateSharedSlice({} as prismicT.SharedSliceModel, params),
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -15,13 +15,20 @@ test("createCustomTypesClient creates a CustomTypesClient", (ctx) => {
 });
 
 test("has correct default state", (ctx) => {
-	const config = createClientConfig(ctx);
+	const config = createClientConfig(ctx, {
+		fetchOptions: {
+			headers: {
+				foo: "bar",
+			},
+		},
+	});
 	const client = prismicCustomTypes.createClient(config);
 
 	expect(client.repositoryName).toBe(config.repositoryName);
 	expect(client.endpoint).toBe(config.endpoint);
 	expect(client.token).toBe(config.token);
 	expect(client.fetchFn).toBe(config.fetch);
+	expect(client.fetchOptions).toStrictEqual(config.fetchOptions);
 });
 
 test("uses the default endpoint if none is provided", (ctx) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a `fetchOptions` parameter to all methods that use `fetch()` (`getAllCustomTypes()`, `updateCustomType()`, etc.).

The option allows developers to add arbitrary options to `fetch()` requests, such as `cache` and `headers`.

`fetchOptions` can be provided to `createClient()`, which will set `fetch()` options for all network requests.

```ts
const client = createClient({
  repositoryName: "example-prismic-repo",
  token: "token",
  fetchOptions: {
    cache: "force-cache",
  },
});
```

Alternatively, `fetchOptions` can be passed to any method that uses `fetch()` in its implementation. Options passed to methods will be merged with and override ones passed to `createClient()`.

```ts
const client = createClient({
  repositoryName: "example-prismic-repo",
  token: "token",
});

const customTypes = await client.getAllCustomTypes({
  fetchOptions: {
    cache: "force-cache",
  },
});
```

The feature works identically to `@prismicio/client`'s `fetchOptions` parameter.

See https://github.com/prismicio/prismic-client/pull/291 for more details on the `@prismcio/client` implementation.

This PR supersedes #8.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🪿
