### PR TITLE
fix: replace `@prismicio/types` with `@prismicio/client`

### DIFF
--- a/examples/custom-types/package.json
+++ b/examples/custom-types/package.json
@@ -5,7 +5,6 @@
 		"node-fetch": "^2.6.1"
 	},
 	"devDependencies": {
-		"@prismicio/types": "^0.1.1",
 		"ts-node": "^10.0.0",
 		"typescript": "^4.3.5"
 	}

--- a/examples/shared-slices/package.json
+++ b/examples/shared-slices/package.json
@@ -5,7 +5,6 @@
 		"node-fetch": "^2.6.1"
 	},
 	"devDependencies": {
-		"@prismicio/types": "^0.1.1",
 		"ts-node": "^10.0.0",
 		"typescript": "^4.3.5"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/types": "^0.2.4"
+				"@prismicio/client": "^7.3.1"
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.1.1",
@@ -691,6 +691,17 @@
 			"integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
 			"dev": true
 		},
+		"node_modules/@prismicio/client": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.3.1.tgz",
+			"integrity": "sha512-9MKR/atr4dIQz8rZsQ4Fe7588qSQF2CYXutYW8O9bJOqlrjvAcC8b1Yvu7AIOksXlxE/aAWPtriQ2JZMiTFjNw==",
+			"dependencies": {
+				"imgix-url-builder": "^0.0.4"
+			},
+			"engines": {
+				"node": ">=14.15.0"
+			}
+		},
 		"node_modules/@prismicio/mock": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.1.1.tgz",
@@ -709,6 +720,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.4.tgz",
 			"integrity": "sha512-du2R+3xPgelqtprOhzVIj3wLJ25/Uz9vP6nLhyXslbg2Gaqh4mvunCzQRPL0ipv7GiK3YRGzA8KvJXu5FxThiw==",
+			"dev": true,
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -3684,6 +3696,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/imgix-url-builder": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.4.tgz",
+			"integrity": "sha512-JRLydfxGTTbSSOG82ewuCgnmw/CzIPzoDqpP3UYD7RE+QWS8ZZbpF87ZuRqtcbEKdxahRsExinuKRxPZVvukWA==",
+			"engines": {
+				"node": ">=12.7.0"
 			}
 		},
 		"node_modules/import-fresh": {
@@ -7578,6 +7598,14 @@
 			"integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
 			"dev": true
 		},
+		"@prismicio/client": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.3.1.tgz",
+			"integrity": "sha512-9MKR/atr4dIQz8rZsQ4Fe7588qSQF2CYXutYW8O9bJOqlrjvAcC8b1Yvu7AIOksXlxE/aAWPtriQ2JZMiTFjNw==",
+			"requires": {
+				"imgix-url-builder": "^0.0.4"
+			}
+		},
 		"@prismicio/mock": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.1.1.tgz",
@@ -7592,7 +7620,8 @@
 		"@prismicio/types": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.4.tgz",
-			"integrity": "sha512-du2R+3xPgelqtprOhzVIj3wLJ25/Uz9vP6nLhyXslbg2Gaqh4mvunCzQRPL0ipv7GiK3YRGzA8KvJXu5FxThiw=="
+			"integrity": "sha512-du2R+3xPgelqtprOhzVIj3wLJ25/Uz9vP6nLhyXslbg2Gaqh4mvunCzQRPL0ipv7GiK3YRGzA8KvJXu5FxThiw==",
+			"dev": true
 		},
 		"@rollup/plugin-typescript": {
 			"version": "10.0.1",
@@ -9685,6 +9714,11 @@
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
 			"integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
 			"dev": true
+		},
+		"imgix-url-builder": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.4.tgz",
+			"integrity": "sha512-JRLydfxGTTbSSOG82ewuCgnmw/CzIPzoDqpP3UYD7RE+QWS8ZZbpF87ZuRqtcbEKdxahRsExinuKRxPZVvukWA=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"unit:watch": "vitest watch"
 	},
 	"dependencies": {
-		"@prismicio/types": "^0.2.4"
+		"@prismicio/client": "^7.3.1"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.1.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import type * as prismicT from "@prismicio/types";
+import type * as prismic from "@prismicio/client";
 
 import type { AbortSignalLike, FetchLike, RequestInitLike } from "./types";
 import {
@@ -189,7 +189,7 @@ export class CustomTypesClient {
 	 * @throws {@link ForbiddenError} Thrown if the client is unauthorized to make
 	 *   requests.
 	 */
-	async getAllCustomTypes<TCustomType extends prismicT.CustomTypeModel>(
+	async getAllCustomTypes<TCustomType extends prismic.CustomTypeModel>(
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TCustomType[]> {
 		return await this.fetch<TCustomType[]>("./customtypes", params);
@@ -208,7 +208,7 @@ export class CustomTypesClient {
 	 * @throws {@link NotFoundError} Thrown if a Custom Type with the given ID
 	 *   cannot be found.
 	 */
-	async getCustomTypeByID<TCustomType extends prismicT.CustomTypeModel>(
+	async getCustomTypeByID<TCustomType extends prismic.CustomTypeModel>(
 		id: string,
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TCustomType> {
@@ -230,7 +230,7 @@ export class CustomTypesClient {
 	 * @throws {@link ConflictError} Thrown if a Custom Type with the given ID
 	 *   already exists.
 	 */
-	async insertCustomType<TCustomType extends prismicT.CustomTypeModel>(
+	async insertCustomType<TCustomType extends prismic.CustomTypeModel>(
 		customType: TCustomType,
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TCustomType> {
@@ -258,7 +258,7 @@ export class CustomTypesClient {
 	 * @throws {@link NotFoundError} Thrown if a Custom Type with the given ID
 	 *   cannot be found.
 	 */
-	async updateCustomType<TCustomType extends prismicT.CustomTypeModel>(
+	async updateCustomType<TCustomType extends prismic.CustomTypeModel>(
 		customType: TCustomType,
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TCustomType> {
@@ -304,7 +304,7 @@ export class CustomTypesClient {
 	 * @throws {@link ForbiddenError} Thrown if the client is unauthorized to make
 	 *   requests.
 	 */
-	async getAllSharedSlices<TSharedSliceModel extends prismicT.SharedSliceModel>(
+	async getAllSharedSlices<TSharedSliceModel extends prismic.SharedSliceModel>(
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TSharedSliceModel[]> {
 		return await this.fetch<TSharedSliceModel[]>("./slices", params);
@@ -324,7 +324,7 @@ export class CustomTypesClient {
 	 * @throws {@link NotFoundError} Thrown if a Shared Slice with the given ID
 	 *   cannot be found.
 	 */
-	async getSharedSliceByID<TSharedSliceModel extends prismicT.SharedSliceModel>(
+	async getSharedSliceByID<TSharedSliceModel extends prismic.SharedSliceModel>(
 		id: string,
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TSharedSliceModel> {
@@ -346,7 +346,7 @@ export class CustomTypesClient {
 	 * @throws {@link ConflictError} Thrown if a Shared Slice with the given ID
 	 *   already exists.
 	 */
-	async insertSharedSlice<TSharedSliceModel extends prismicT.SharedSliceModel>(
+	async insertSharedSlice<TSharedSliceModel extends prismic.SharedSliceModel>(
 		slice: TSharedSliceModel,
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TSharedSliceModel> {
@@ -374,7 +374,7 @@ export class CustomTypesClient {
 	 * @throws {@link NotFoundError} Thrown if a Shared Slice with the given ID
 	 *   cannot be found.
 	 */
-	async updateSharedSlice<TSharedSliceModel extends prismicT.SharedSliceModel>(
+	async updateSharedSlice<TSharedSliceModel extends prismic.SharedSliceModel>(
 		slice: TSharedSliceModel,
 		params?: CustomTypesClientMethodParams & FetchParams,
 	): Promise<TSharedSliceModel> {

--- a/test/client-insertCustomType.test.ts
+++ b/test/client-insertCustomType.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
-import * as prismicT from "@prismicio/types";
+import * as prismic from "@prismicio/client";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
@@ -141,5 +141,5 @@ testFetchOptions("supports fetch options", {
 	mockURL: (client) => new URL("./customtypes/insert", client.endpoint),
 	mockURLMethod: "post",
 	run: (client, params) =>
-		client.insertCustomType({} as prismicT.CustomTypeModel, params),
+		client.insertCustomType({} as prismic.CustomTypeModel, params),
 });

--- a/test/client-insertSharedSlice.test.ts
+++ b/test/client-insertSharedSlice.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
-import * as prismicT from "@prismicio/types";
+import * as prismic from "@prismicio/client";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
@@ -143,5 +143,5 @@ testFetchOptions("supports fetch options", {
 	mockURL: (client) => new URL("./slices/insert", client.endpoint),
 	mockURLMethod: "post",
 	run: (client, params) =>
-		client.insertSharedSlice({} as prismicT.SharedSliceModel, params),
+		client.insertSharedSlice({} as prismic.SharedSliceModel, params),
 });

--- a/test/client-updateCustomType.test.ts
+++ b/test/client-updateCustomType.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
-import * as prismicT from "@prismicio/types";
+import * as prismic from "@prismicio/client";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
@@ -141,5 +141,5 @@ testFetchOptions("supports fetch options", {
 	mockURL: (client) => new URL("./customtypes/update", client.endpoint),
 	mockURLMethod: "post",
 	run: (client, params) =>
-		client.updateCustomType({} as prismicT.CustomTypeModel, params),
+		client.updateCustomType({} as prismic.CustomTypeModel, params),
 });

--- a/test/client-updateSharedSlice.test.ts
+++ b/test/client-updateSharedSlice.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "vitest";
 import * as msw from "msw";
 import * as assert from "assert";
-import * as prismicT from "@prismicio/types";
+import * as prismic from "@prismicio/client";
 
 import { createClient } from "./__testutils__/createClient";
 import { isAuthorizedRequest } from "./__testutils__/isAuthorizedRequest";
@@ -143,5 +143,5 @@ testFetchOptions("supports fetch options", {
 	mockURL: (client) => new URL("./slices/update", client.endpoint),
 	mockURLMethod: "post",
 	run: (client, params) =>
-		client.updateSharedSlice({} as prismicT.SharedSliceModel, params),
+		client.updateSharedSlice({} as prismic.SharedSliceModel, params),
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR replaces `@prismicio/types` (deprecated) with `@prismicio/client`.

All types from `@prismicio/types` are provided by `@prismicio/client` as a drop-in replacement.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
